### PR TITLE
fix to use options identifier

### DIFF
--- a/lib/proof/proof_actions.rb
+++ b/lib/proof/proof_actions.rb
@@ -20,7 +20,8 @@ module Proof
     module LocalInstanceMethods
       def login
         proof_class = self.class.proof_options[:authenticatable].to_s.camelize.constantize
-        user = proof_class.find_by(self.class.proof_options[:identifier] => params[:identifier])
+        identifier = self.class.proof_options[:identifier]
+        user = proof_class.find_by(identifier => params[identifier])
         if user && user.send(self.class.proof_options[:authenticate], params[self.class.proof_options[:password]])
           render json: { auth_token: Proof::Token.from_data({ user_id: user.id }) }
         else

--- a/lib/proof/version.rb
+++ b/lib/proof/version.rb
@@ -1,3 +1,3 @@
 module Proof
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end

--- a/test/proof_actions_test.rb
+++ b/test/proof_actions_test.rb
@@ -8,7 +8,7 @@ class ProofActionsTest < ActionController::TestCase
     @controller = AuthenticationController.new
     @request = ActionController::TestRequest.new
     @response = ActionController::TestResponse.new
-    
+
     Rails.application.routes.draw do
       post 'login' => 'authentication#login'
     end
@@ -19,12 +19,12 @@ class ProofActionsTest < ActionController::TestCase
   end
 
   def test_proof_actions_invalid_user_returns_unauthorized
-    post :login, { 'identifier' => 'fake@email.com', 'password' => 'password' }
+    post :login, { 'email' => 'fake@email.com', 'password' => 'password' }
     assert_response :unauthorized
   end
 
   def test_proof_actions_valid_user_returns_token
-    post :login, { 'identifier' => 'real@email.com', 'password' => 'realpassword' }
+    post :login, { 'email' => 'real@email.com', 'password' => 'realpassword' }
     response = JSON.parse(@response.body)
 
     assert_response :success


### PR DESCRIPTION
The lib was directly looking for `params[:identifier]` should have been looking for the `proof_options[:identifier]`
